### PR TITLE
[fix] 채팅방 구독 해제 버그 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.swapit.oopswap"
         minSdk = 29
         targetSdk = 35
-        versionCode = 29
-        versionName = "29.0.0"
+        versionCode = 30
+        versionName = "2.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.swapit.oopswap"
         minSdk = 29
         targetSdk = 35
-        versionCode = 28
-        versionName = "28.0.0"
+        versionCode = 29
+        versionName = "29.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
+++ b/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
@@ -93,7 +93,7 @@ class StompModule(
     private fun subscribeAlert() {
         scope.launch {
             if (stompSession == null) {
-                Log.e("STOMP", "알림 구독 연결 실패")
+                Log.e(TAG, "알림 구독 연결 실패")
                 return@launch
             }
             try {
@@ -105,23 +105,23 @@ class StompModule(
                         ),
                     )
 
-                Log.d("STOMP", "알림 구독 성공!")
+                Log.d(TAG, "알림 구독 성공!")
 
                 messageFlow.collect { frame ->
-                    Log.d("STOMP", "알림 수신: ${frame.bodyAsText}")
+                    Log.d(TAG, "알림 수신: ${frame.bodyAsText}")
                     frame.bodyAsText?.let { jsonMessage ->
                         try {
                             val notification = Json.decodeFromString<NotificationResponse>(jsonMessage)
                             handleNotification(notification)
                         } catch (e: Exception) {
-                            Log.e("STOMP", "알림 처리 실패: ${e.message}")
+                            Log.e(TAG, "알림 처리 실패: ${e.message}")
                         }
                     }
                 }
             } catch (e: CancellationException) {
-                Log.d("STOMP", "알림 구독 취소")
+                Log.d(TAG, "알림 구독 취소")
             } catch (e: Exception) {
-                Log.e("STOMP", "알림 구독 실패: ${e.message}")
+                Log.e(TAG, "알림 구독 실패: ${e.message}")
             }
         }
     }
@@ -153,7 +153,7 @@ class StompModule(
         val job =
             scope.launch(SupervisorJob()) {
                 if (stompSession == null) {
-                    Log.e("STOMP", "채팅방 구독 연결 실패")
+                    Log.e(TAG, "채팅방 구독 연결 실패")
                     disconnect()
                     connect()
                     return@launch
@@ -169,24 +169,24 @@ class StompModule(
                             ),
                         )
 
-                    Log.d("STOMP", "채팅방 구독 성공 : $chatRoomId")
+                    Log.d(TAG, "채팅방 구독 성공 : $chatRoomId")
 
                     messageFlow.collect { frame ->
-                        Log.d("STOMP", "채팅 메시지 수신: ${frame.bodyAsText}")
+                        Log.d(TAG, "채팅 메시지 수신: ${frame.bodyAsText}")
                         frame.bodyAsText?.let { jsonMessage ->
                             try {
                                 val receivedChat = Json.decodeFromString<ChatResponse>(jsonMessage)
                                 if (chatList.any { it.chatsId == receivedChat.chatsId }) return@let
                                 chatList.add(receivedChat.toDomain())
                             } catch (e: Exception) {
-                                Log.e("STOMP", "메시지 처리 실패: ${e.message}")
+                                Log.e(TAG, "메시지 처리 실패: ${e.message}")
                             }
                         }
                     }
                 } catch (e: CancellationException) {
-                    Log.d("STOMP", "채팅방 구독 취소: $chatRoomId")
+                    Log.d(TAG, "채팅방 구독 취소: $chatRoomId")
                 } catch (e: Exception) {
-                    Log.e("STOMP", "채팅방 구독 실패: $e")
+                    Log.e(TAG, "채팅방 구독 실패: $e")
                 }
             }
         subscriptionJobs[chatRoomId] = job
@@ -215,7 +215,7 @@ class StompModule(
             val job = subscriptionJobs.remove(chatRoomId)
             job?.cancel()
 
-            Log.d("STOMP", "채팅방 구독 해지: chatRoomId=$chatRoomId")
+            Log.d(TAG, "채팅방 구독 해지: chatRoomId=$chatRoomId")
         }
     }
 
@@ -297,9 +297,9 @@ class StompModule(
                             Json.encodeToString(ChatReadRequest.serializer(), ChatReadRequest(chatList.first().chatsId)) + "\\0",
                         ),
                 )
-                Log.d("STOMP", "읽음 처리 전송 성공: ${chatList.first().chatsId}")
+                Log.d(TAG, "읽음 처리 전송 성공: ${chatList.first().chatsId}")
             } catch (e: Exception) {
-                Log.e("STOMP", "읽음 처리 전송 실패: ${e.message}")
+                Log.e(TAG, "읽음 처리 전송 실패: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
+++ b/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
@@ -195,9 +195,26 @@ class StompModule(
 
     fun unsubscribeFromChatRoom(chatRoomId: Long) {
         scope.launch {
+            // 1. 서버에 구독 해제 전송
+            stompSession?.send(
+                headers =
+                    StompSendHeaders(
+                        destination = "/app/chat/unsubscribe/$chatRoomId",
+                        customHeaders =
+                            mapOf(
+                                "content-type" to "application/json",
+                                "Authorization" to "Bearer ${loginRepository.accessToken() ?: ""}",
+                            ),
+                    ),
+                body = FrameBody.Text("\\0"),
+            )
+            kotlinx.coroutines.delay(100)
+
+            // 2. 클라이언트 측 구독 관리 정리
             subscriptionIds.remove(chatRoomId)
             val job = subscriptionJobs.remove(chatRoomId)
             job?.cancel()
+
             Log.d("STOMP", "채팅방 구독 해지: chatRoomId=$chatRoomId")
         }
     }

--- a/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
+++ b/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
@@ -19,6 +19,7 @@ import com.swapit.oopswap.data.mapper.toDomain
 import com.swapit.oopswap.domain.model.chat.Chat
 import com.swapit.oopswap.domain.repository.LoginRepository
 import com.swapit.oopswap.ui.base.AlertNotifier
+import com.swapit.oopswap.ui.chat.ChatViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -170,11 +171,12 @@ class StompModule(
     fun subscribeToChatRoom(
         chatRoomId: Long,
         chatList: SnapshotStateList<Chat>,
+        chatViewModel: ChatViewModel? = null,
     ) {
         scope.launch {
             try {
                 ensureConnection()
-                
+
                 if (subscriptionJobs.containsKey(chatRoomId)) {
                     Log.d(TAG, "이미 구독 중인 채팅방: $chatRoomId")
                     return@launch
@@ -203,10 +205,12 @@ class StompModule(
                                     try {
                                         val receivedChat = Json.decodeFromString<ChatResponse>(jsonMessage)
                                         val chat = receivedChat.toDomain()
-                                        
+
                                         // 수신된 메시지만 chatList에 추가
                                         if (!chatList.any { it.chatsId == chat.chatsId }) {
                                             chatList.add(chat)
+                                            // 마지막으로 읽은 메시지 ID 업데이트
+                                            chatViewModel?.updateLastReadChatId(chat.chatsId)
                                             Log.d(TAG, "새 메시지 추가: ${chat.chatsId}")
                                         } else {
                                             Log.d(TAG, "중복 메시지 무시: ${chat.chatsId}")
@@ -328,9 +332,8 @@ class StompModule(
 
     fun sendReadReceipt(
         chatRoomId: Long,
-        chatList: List<Chat>,
+        lastReadChatId: Long,
     ) {
-        if (chatList.isEmpty()) return
         scope.launch {
             try {
                 stompSession?.send(
@@ -345,10 +348,10 @@ class StompModule(
                         ),
                     body =
                         FrameBody.Text(
-                            Json.encodeToString(ChatReadRequest.serializer(), ChatReadRequest(chatList.first().chatsId)) + "\\0",
+                            Json.encodeToString(ChatReadRequest.serializer(), ChatReadRequest(lastReadChatId)) + "\\0",
                         ),
                 )
-                Log.d(TAG, "읽음 처리 전송 성공: ${chatList.first().chatsId}")
+                Log.d(TAG, "읽음 처리 전송 성공: $lastReadChatId")
             } catch (e: Exception) {
                 Log.e(TAG, "읽음 처리 전송 실패: ${e.message}")
             }

--- a/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
+++ b/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.app.NotificationManager
 import android.content.Context
 import android.util.Log
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.core.app.NotificationCompat
 import com.swapit.oopswap.BuildConfig
@@ -45,10 +46,29 @@ class StompModule(
     private val subscriptionCounter = AtomicInteger(0)
     private val subscriptionIds = ConcurrentHashMap<Long, String>()
     private val subscriptionJobs = ConcurrentHashMap<Long, Job>()
+    private val activeSubscriptions = ConcurrentHashMap<Long, Boolean>() // 구독 상태 추적
     private val wsClient by lazy { OkHttpWebSocketClient(okHttpClient()) }
     private val stompClient = StompClient(wsClient)
     private var stompSession: StompSession? = null
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var isConnecting = false
+
+    private suspend fun ensureConnection() {
+        if (stompSession == null && !isConnecting) {
+            isConnecting = true
+            try {
+                connect()
+                // 재연결 시 이전 구독 복구
+                activeSubscriptions.forEach { (chatRoomId, isActive) ->
+                    if (isActive) {
+                        subscribeToChatRoom(chatRoomId, mutableStateListOf())
+                    }
+                }
+            } finally {
+                isConnecting = false
+            }
+        }
+    }
 
     fun connectAndMonitor() {
         scope.launch {
@@ -151,75 +171,98 @@ class StompModule(
         chatRoomId: Long,
         chatList: SnapshotStateList<Chat>,
     ) {
-        if (subscriptionJobs.containsKey(chatRoomId)) {
-            Log.d(TAG, "이미 구독 중인 채팅방: $chatRoomId")
-            return
-        }
-        val job =
-            scope.launch(SupervisorJob()) {
-                if (stompSession == null) {
-                    Log.e(TAG, "채팅방 구독 연결 실패")
-                    disconnect()
-                    connect()
+        scope.launch {
+            try {
+                ensureConnection()
+                
+                if (subscriptionJobs.containsKey(chatRoomId)) {
+                    Log.d(TAG, "이미 구독 중인 채팅방: $chatRoomId")
                     return@launch
                 }
-                try {
-                    val subId = "chat-sub-${subscriptionCounter.incrementAndGet()}"
-                    subscriptionIds[chatRoomId] = subId
-                    val messageFlow =
-                        stompSession!!.subscribe(
-                            StompSubscribeHeaders(
-                                destination = "/topic/chat/$chatRoomId",
-                                id = subId,
-                            ),
-                        )
 
-                    Log.d(TAG, "채팅방 구독 성공 : $chatRoomId")
+                val job =
+                    scope.launch(SupervisorJob()) {
+                        try {
+                            val subId = "chat-sub-${subscriptionCounter.incrementAndGet()}"
+                            subscriptionIds[chatRoomId] = subId
+                            activeSubscriptions[chatRoomId] = true
 
-                    messageFlow.collect { frame ->
-                        Log.d(TAG, "채팅 메시지 수신: ${frame.bodyAsText}")
-                        frame.bodyAsText?.let { jsonMessage ->
-                            try {
-                                val receivedChat = Json.decodeFromString<ChatResponse>(jsonMessage)
-                                if (chatList.any { it.chatsId == receivedChat.chatsId }) return@let
-                                chatList.add(receivedChat.toDomain())
-                            } catch (e: Exception) {
-                                Log.e(TAG, "메시지 처리 실패: ${e.message}")
+                            val messageFlow =
+                                stompSession!!.subscribe(
+                                    StompSubscribeHeaders(
+                                        destination = "/topic/chat/$chatRoomId",
+                                        id = subId,
+                                    ),
+                                )
+
+                            Log.d(TAG, "채팅방 구독 성공 : $chatRoomId")
+
+                            messageFlow.collect { frame ->
+                                Log.d(TAG, "채팅 메시지 수신: ${frame.bodyAsText}")
+                                frame.bodyAsText?.let { jsonMessage ->
+                                    try {
+                                        val receivedChat = Json.decodeFromString<ChatResponse>(jsonMessage)
+                                        val chat = receivedChat.toDomain()
+                                        
+                                        // 수신된 메시지만 chatList에 추가
+                                        if (!chatList.any { it.chatsId == chat.chatsId }) {
+                                            chatList.add(chat)
+                                            Log.d(TAG, "새 메시지 추가: ${chat.chatsId}")
+                                        } else {
+                                            Log.d(TAG, "중복 메시지 무시: ${chat.chatsId}")
+                                        }
+                                    } catch (e: Exception) {
+                                        Log.e(TAG, "메시지 처리 실패: ${e.message}")
+                                    }
+                                }
                             }
+                        } catch (e: CancellationException) {
+                            Log.d(TAG, "채팅방 구독 취소: $chatRoomId")
+                            activeSubscriptions.remove(chatRoomId)
+                        } catch (e: Exception) {
+                            Log.e(TAG, "채팅방 구독 실패: $e")
+                            activeSubscriptions.remove(chatRoomId)
                         }
                     }
-                } catch (e: CancellationException) {
-                    Log.d(TAG, "채팅방 구독 취소: $chatRoomId")
-                } catch (e: Exception) {
-                    Log.e(TAG, "채팅방 구독 실패: $e")
-                }
+                subscriptionJobs[chatRoomId] = job
+            } catch (e: Exception) {
+                Log.e(TAG, "구독 설정 실패: ${e.message}")
             }
-        subscriptionJobs[chatRoomId] = job
+        }
     }
 
     suspend fun unsubscribeFromChatRoom(chatRoomId: Long) {
         scope.launch {
-            // 1. 서버에 구독 해제 전송
-            stompSession?.send(
-                headers =
-                    StompSendHeaders(
-                        destination = "/app/chat/unsubscribe/$chatRoomId",
-                        customHeaders =
-                            mapOf(
-                                "content-type" to "application/json",
-                                "Authorization" to "Bearer ${loginRepository.accessToken() ?: ""}",
-                            ),
-                    ),
-                body = FrameBody.Text("\\0"),
-            )
-            kotlinx.coroutines.delay(100)
+            try {
+                // 1. 서버에 구독 해제 요청 전송
+                stompSession?.send(
+                    headers =
+                        StompSendHeaders(
+                            destination = "/app/chat/unsubscribe/$chatRoomId",
+                            customHeaders =
+                                mapOf(
+                                    "content-type" to "application/json",
+                                    "Authorization" to "Bearer ${loginRepository.accessToken() ?: ""}",
+                                ),
+                        ),
+                    body = FrameBody.Text("\\0"),
+                )
 
-            // 2. 클라이언트 측 구독 관리 정리
-            subscriptionIds.remove(chatRoomId)
-            val job = subscriptionJobs.remove(chatRoomId)
-            job?.cancelAndJoin()
+                // 2. 클라이언트 측 구독 관리 정리
+                activeSubscriptions.remove(chatRoomId)
+                subscriptionIds.remove(chatRoomId)
+                val job = subscriptionJobs.remove(chatRoomId)
+                job?.cancelAndJoin()
 
-            Log.d(TAG, "채팅방 구독 해지: chatRoomId=$chatRoomId")
+                Log.d(TAG, "채팅방 구독 해지 완료: chatRoomId=$chatRoomId")
+            } catch (e: Exception) {
+                Log.e(TAG, "채팅방 구독 해지 실패: ${e.message}")
+                // 실패 시에도 클라이언트 측 정리는 수행
+                activeSubscriptions.remove(chatRoomId)
+                subscriptionIds.remove(chatRoomId)
+                val job = subscriptionJobs.remove(chatRoomId)
+                job?.cancelAndJoin()
+            }
         }
     }
 
@@ -239,12 +282,16 @@ class StompModule(
         if (message.content == "") return
         scope.launch {
             try {
+                ensureConnection()
+
                 if (isAccessTokenExpired()) {
                     val newTokens = loginRepository.refresh(loginRepository.refreshToken()!!)
                     connect()
                     subscribeAlert()
                     Log.d(TAG, "액세스 토큰 갱신 성공: ${newTokens.accessToken}")
                 }
+
+                // 메시지 전송만 수행
                 stompSession?.send(
                     headers =
                         StompSendHeaders(
@@ -257,7 +304,7 @@ class StompModule(
                         ),
                     body = FrameBody.Text(Json.encodeToString(ChatRequest.serializer(), message) + "\\0"),
                 )
-                kotlinx.coroutines.delay(100)
+
                 Log.d(TAG, "채팅 메시지 전송 성공: $message")
             } catch (e: Exception) {
                 Log.e(TAG, "채팅 메시지 전송 실패: ${e.message}")

--- a/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
+++ b/app/src/main/java/com/swapit/oopswap/data/datasource/remote/StompModule.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.time.delay
 import kotlinx.serialization.json.Json
@@ -149,7 +150,11 @@ class StompModule(
     fun subscribeToChatRoom(
         chatRoomId: Long,
         chatList: SnapshotStateList<Chat>,
-    ): SnapshotStateList<Chat> {
+    ) {
+        if (subscriptionJobs.containsKey(chatRoomId)) {
+            Log.d(TAG, "이미 구독 중인 채팅방: $chatRoomId")
+            return
+        }
         val job =
             scope.launch(SupervisorJob()) {
                 if (stompSession == null) {
@@ -190,10 +195,9 @@ class StompModule(
                 }
             }
         subscriptionJobs[chatRoomId] = job
-        return chatList
     }
 
-    fun unsubscribeFromChatRoom(chatRoomId: Long) {
+    suspend fun unsubscribeFromChatRoom(chatRoomId: Long) {
         scope.launch {
             // 1. 서버에 구독 해제 전송
             stompSession?.send(
@@ -213,7 +217,7 @@ class StompModule(
             // 2. 클라이언트 측 구독 관리 정리
             subscriptionIds.remove(chatRoomId)
             val job = subscriptionJobs.remove(chatRoomId)
-            job?.cancel()
+            job?.cancelAndJoin()
 
             Log.d(TAG, "채팅방 구독 해지: chatRoomId=$chatRoomId")
         }

--- a/app/src/main/java/com/swapit/oopswap/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/swapit/oopswap/ui/chat/ChatViewModel.kt
@@ -56,21 +56,6 @@ class ChatViewModel(
         stompModule.sendMessage(message, chatRoomId)
     }
 
-    fun enterChatRoom(newChatRoomId: Long) {
-        safeLaunch {
-            // 기존 채팅방 구독 해제 (필요할 때만)
-            if (chatRoomId.longValue != 0L) {
-                stompModule.unsubscribeFromChatRoom(chatRoomId.longValue)
-            }
-
-            // 새로운 채팅방 ID 설정
-            chatRoomId.longValue = newChatRoomId
-
-            // 새로운 채팅방 구독
-            stompModule.subscribeToChatRoom(newChatRoomId, chatList)
-        }
-    }
-
     private suspend fun createChatRoomSync(goodsId: GoodsIdRequest): Long = repository.createChatRoom(goodsId).results
 
     private suspend fun createChatRoomTradeSync(tradesId: TradesIdRequest): Long = repository.createSwapChatRoom(tradesId).results
@@ -86,12 +71,26 @@ class ChatViewModel(
 
             if (chatRoomId != 0L) {
                 chatRoomProduct.value = repository.chatRoomInfo(chatRoomId)
-                val initialChatList = mutableStateListOf<Chat>()
-                chatList = stompModule.subscribeToChatRoom(chatRoomId, initialChatList)
+
+                stompModule.unsubscribeFromChatRoom(chatRoomId) // 기존 구독 해제
+                chatList = mutableStateListOf() // 새로운 채팅방 구독
+                stompModule.subscribeToChatRoom(chatRoomId, chatList)
                 navController.navigate(NavItem.ChatRoom.screenRoute + "/$chatRoomId")
             } else {
                 Log.e("ChatViewModel", "Chat room ID is not set. Failed to navigate.")
             }
+        }
+    }
+
+    fun enterChatRoom(newChatRoomId: Long) {
+        safeLaunch {
+            if (chatRoomId.longValue != 0L && chatRoomId.longValue != newChatRoomId) {
+                stompModule.unsubscribeFromChatRoom(chatRoomId.longValue)
+            }
+
+            chatRoomId.longValue = newChatRoomId
+            chatList = mutableStateListOf() // 채팅 리스트 초기화
+            stompModule.subscribeToChatRoom(newChatRoomId, chatList)
         }
     }
 

--- a/app/src/main/java/com/swapit/oopswap/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/swapit/oopswap/ui/chat/ChatViewModel.kt
@@ -32,6 +32,7 @@ class ChatViewModel(
     val chatRoomId = mutableLongStateOf(0L)
     val goodsId = mutableLongStateOf(0L)
     val tradesId = mutableLongStateOf(0L)
+    private var lastReadChatId: Long = 0L // 마지막으로 읽은 메시지 ID 저장
     val chatRoomProduct =
         mutableStateOf(
             ChatRoomInfo(
@@ -46,7 +47,16 @@ class ChatViewModel(
         )
 
     fun sendReadReceipt(chatRoomId: Long) {
-        stompModule.sendReadReceipt(chatRoomId, chatList)
+        // 마지막으로 읽은 메시지 ID가 있는 경우에만 전송
+        if (lastReadChatId > 0) {
+            stompModule.sendReadReceipt(chatRoomId, lastReadChatId)
+        }
+    }
+
+    fun updateLastReadChatId(chatId: Long) {
+        if (chatId > lastReadChatId) {
+            lastReadChatId = chatId
+        }
     }
 
     fun sendMessage(
@@ -75,7 +85,7 @@ class ChatViewModel(
 
                 stompModule.unsubscribeFromChatRoom(chatRoomId) // 기존 구독 해제
                 chatList = mutableStateListOf() // 새로운 채팅방 구독
-                stompModule.subscribeToChatRoom(chatRoomId, chatList)
+                stompModule.subscribeToChatRoom(chatRoomId, chatList, this@ChatViewModel)
                 navController.navigate(NavItem.ChatRoom.screenRoute + "/$chatRoomId")
             } else {
                 Log.e("ChatViewModel", "Chat room ID is not set. Failed to navigate.")
@@ -96,7 +106,7 @@ class ChatViewModel(
             fetchChatList(newChatRoomId)
             
             // 웹소켓 구독 시작
-            stompModule.subscribeToChatRoom(newChatRoomId, chatList)
+            stompModule.subscribeToChatRoom(newChatRoomId, chatList, this@ChatViewModel)
         }
     }
 
@@ -111,7 +121,7 @@ class ChatViewModel(
             if (chatRoomId != 0L) {
                 chatRoomProduct.value = repository.chatRoomInfo(chatRoomId)
                 val initialChatList = mutableStateListOf<Chat>()
-                chatList = stompModule.subscribeToChatRoom(chatRoomId, initialChatList) as SnapshotStateList<Chat>
+                chatList = stompModule.subscribeToChatRoom(chatRoomId, initialChatList, this@ChatViewModel) as SnapshotStateList<Chat>
                 navController.navigate(NavItem.ChatRoom.screenRoute + "/$chatRoomId")
             } else {
                 Log.e("ChatViewModel", "Chat room ID is not set. Failed to navigate.")

--- a/app/src/main/java/com/swapit/oopswap/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/swapit/oopswap/ui/chat/ChatViewModel.kt
@@ -53,6 +53,7 @@ class ChatViewModel(
         message: ChatRequest,
         chatRoomId: Long,
     ) {
+        // 메시지 전송만 수행하고 채팅 목록 조회는 하지 않음
         stompModule.sendMessage(message, chatRoomId)
     }
 
@@ -90,6 +91,11 @@ class ChatViewModel(
 
             chatRoomId.longValue = newChatRoomId
             chatList = mutableStateListOf() // 채팅 리스트 초기화
+            
+            // 채팅방 입장 시 한 번만 이전 메시지 로드
+            fetchChatList(newChatRoomId)
+            
+            // 웹소켓 구독 시작
             stompModule.subscribeToChatRoom(newChatRoomId, chatList)
         }
     }
@@ -131,9 +137,14 @@ class ChatViewModel(
 
     fun fetchChatList(chatroomId: Long) {
         safeLaunch {
-            val newChatList = repository.chatList(chatroomId).chatList.map { it.toDomain() }
-            chatList.clear()
-            chatList.addAll(newChatList)
+            try {
+                val newChatList = repository.chatList(chatroomId).chatList.map { it.toDomain() }
+                chatList.clear()
+                chatList.addAll(newChatList)
+                Log.d(TAG, "이전 채팅 메시지 로드 완료: ${newChatList.size}개")
+            } catch (e: Exception) {
+                Log.e(TAG, "채팅 메시지 로드 실패: ${e.message}")
+            }
         }
     }
 

--- a/app/src/main/java/com/swapit/oopswap/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/swapit/oopswap/ui/chat/ChatViewModel.kt
@@ -56,6 +56,7 @@ class ChatViewModel(
     fun updateLastReadChatId(chatId: Long) {
         if (chatId > lastReadChatId) {
             lastReadChatId = chatId
+            Log.d(TAG, "마지막 읽은 메시지 ID 업데이트: $chatId")
         }
     }
 
@@ -101,10 +102,10 @@ class ChatViewModel(
 
             chatRoomId.longValue = newChatRoomId
             chatList = mutableStateListOf() // 채팅 리스트 초기화
-            
+
             // 채팅방 입장 시 한 번만 이전 메시지 로드
             fetchChatList(newChatRoomId)
-            
+
             // 웹소켓 구독 시작
             stompModule.subscribeToChatRoom(newChatRoomId, chatList, this@ChatViewModel)
         }
@@ -151,6 +152,19 @@ class ChatViewModel(
                 val newChatList = repository.chatList(chatroomId).chatList.map { it.toDomain() }
                 chatList.clear()
                 chatList.addAll(newChatList)
+
+                // 채팅 메시지 목록이 있으면 마지막 메시지의 ID를 lastReadChatId로 설정
+                if (newChatList.isNotEmpty()) {
+                    val lastChat = newChatList.maxByOrNull { it.chatsId }
+                    lastChat?.let {
+                        lastReadChatId = it.chatsId
+                        Log.d(TAG, "채팅 목록 로드 후 마지막 메시지 ID 설정: ${it.chatsId}")
+                    }
+                } else {
+                    lastReadChatId = 0L
+                    Log.d(TAG, "채팅 목록이 비어있어 마지막 메시지 ID를 0으로 초기화")
+                }
+
                 Log.d(TAG, "이전 채팅 메시지 로드 완료: ${newChatList.size}개")
             } catch (e: Exception) {
                 Log.e(TAG, "채팅 메시지 로드 실패: ${e.message}")
@@ -161,8 +175,8 @@ class ChatViewModel(
     fun fetchChatRoomList() {
         safeLaunch {
             val newChatRoomList = repository.chatRoomList() // 여기서 ArrayList 반환
-            chatRoomList.clear() // ✅ 기존 리스트 비우기
-            chatRoomList.addAll(newChatRoomList) // ✅ 새로운 데이터 추가
+            chatRoomList.clear() // 기존 리스트 비우기
+            chatRoomList.addAll(newChatRoomList) // 새로운 데이터 추가
         }
     }
 

--- a/app/src/main/java/com/swapit/oopswap/ui/chat/room/BottomChatBar.kt
+++ b/app/src/main/java/com/swapit/oopswap/ui/chat/room/BottomChatBar.kt
@@ -77,7 +77,6 @@ fun BottomChatBar(
                 chatRoomId,
             )
             message = ""
-            viewModel.fetchChatList(viewModel.chatRoomId.longValue)
         }) {
             Box(
                 modifier =

--- a/app/src/main/java/com/swapit/oopswap/ui/chat/room/ChatRoomScreen.kt
+++ b/app/src/main/java/com/swapit/oopswap/ui/chat/room/ChatRoomScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
@@ -26,7 +27,10 @@ fun ChatRoomScreen(
     userInfoViewModel: UserInfoViewModel,
     stompModule: StompModule,
 ) {
-    chatViewModel.fetchChatList(chatRoomId.toLong())
+    LaunchedEffect(chatRoomId) {
+        chatViewModel.fetchChatList(chatRoomId.toLong())
+    }
+    
     DisposableEffect(Unit) {
         onDispose {
             chatViewModel.viewModelScope.launch {

--- a/app/src/main/java/com/swapit/oopswap/ui/chat/room/ChatRoomScreen.kt
+++ b/app/src/main/java/com/swapit/oopswap/ui/chat/room/ChatRoomScreen.kt
@@ -30,7 +30,7 @@ fun ChatRoomScreen(
     LaunchedEffect(chatRoomId) {
         chatViewModel.fetchChatList(chatRoomId.toLong())
     }
-    
+
     DisposableEffect(Unit) {
         onDispose {
             chatViewModel.viewModelScope.launch {


### PR DESCRIPTION
- closed #이슈넘버

## 작업 영상

## 작업한 내용
- 채팅 전송 버튼 클릭 시, 반복된 채팅 목록 조회 API 호출 제거
  - 웹소켓으로 수신된 내용만 반영 
- 채팅방 웹소켓 구독 해지 명시적 추가

## PR 포인트
-

## 🚀Next Feature
